### PR TITLE
fix: remove import of CSS file from index.js and modify the README to…

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Example of filtering table data and export, print buttons.
 import React from 'react';
 import DataTable from 'react-data-table-component';
 import DataTableExtensions from 'react-data-table-component-extensions';
+import 'react-data-table-component-extensions/dist/index.css';
 import { columns, data } from './Data.js';
 
 function App() {

--- a/dist/index.js
+++ b/dist/index.js
@@ -9,8 +9,6 @@ var _react = _interopRequireWildcard(require("react"));
 
 var _propTypes = _interopRequireDefault(require("prop-types"));
 
-require("./index.css");
-
 var _ui = require("./ui");
 
 var _utilities = _interopRequireDefault(require("./utilities"));

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import './index.css';
 import { Filter, Export, Print } from './ui';
 import Utilities from './utilities';
 import ExportMethod from './export';


### PR DESCRIPTION
This is the fix discussed in issue #12 

This is a breaking change - if anyone updates their package without inserting the CSS import the styling will break - therefore it needs a major version increase.

Changes made:

- index.css reference removed from index.js
- README updated to include the reference to the CSS file
- An `npm build` was run and the resulting `dist/` files are included.